### PR TITLE
Fixed issue with padding removing transparency (Again)

### DIFF
--- a/src/main/java/org/imgscalr/Scalr.java
+++ b/src/main/java/org/imgscalr/Scalr.java
@@ -1044,9 +1044,12 @@ public class Scalr {
 
 		Graphics g = result.getGraphics();
 
-		// "Clear" the background of the new image with our padding color first.
+		// Draw the border of the image in the color specified.
 		g.setColor(color);
-		g.fillRect(0, 0, newWidth, newHeight);
+		g.fillRect(0, 0, newWidth, padding);
+		g.fillRect(0, padding, padding, newHeight);
+		g.fillRect(padding, newHeight - padding, newWidth, newHeight);
+		g.fillRect(newWidth - padding, padding, newWidth, newHeight - padding);
 
 		// Draw the image into the center of the new padded image.
 		g.drawImage(src, padding, padding, null);


### PR DESCRIPTION
Due to a problem with git (that is probably related to line endings), I am resubmitting this pull request

--

Previously, the entire new image was filled with a background color and then the old image was drawn over it. This broke transparency because the background behind the image was being filled in.

Now, only the padded areas are filled in (in the form of 4, non-overlapping rectangles).

I tested this with a random set of images on my computer and everything worked fine. The average speed remained the same on the set of 145 images.

I did not run any formal tests because I don't know how and this is my first pull request (ever). Some help running the actual tests would be great!
