### PR TITLE
Modified dimension check for new BufferedImage()

### DIFF
--- a/src/main/java/org/imgscalr/Scalr.java
+++ b/src/main/java/org/imgscalr/Scalr.java
@@ -2030,9 +2030,9 @@ public class Scalr {
 	 */
 	protected static BufferedImage createOptimalImage(BufferedImage src,
 			int width, int height) throws IllegalArgumentException {
-		if (width < 0 || height < 0)
+		if (width <= 0 || height <= 0)
 			throw new IllegalArgumentException("width [" + width
-					+ "] and height [" + height + "] must be >= 0");
+					+ "] and height [" + height + "] must be > 0");
 
 		return new BufferedImage(
 				width,


### PR DESCRIPTION
Instantiating BufferedImage requires height and width to be greater than 0.
Please refer to DirectColorModel.createCompatibleWritableRaster() which gets called from BufferedImage's constructor which is called at line imgscalr:2037.