### PR TITLE
Ensure that TargetHeight is not zero

### DIFF
--- a/src/main/java/org/imgscalr/Scalr.java
+++ b/src/main/java/org/imgscalr/Scalr.java
@@ -1653,7 +1653,7 @@ public class Scalr {
 				 * re-calculate a proportionally correct value based on the
 				 * targetWidth.
 				 */
-				targetHeight = Math.round((float) targetWidth * ratio);
+				targetHeight = (int)Math.ceil((float) targetWidth * ratio);
 
 				if (DEBUG && originalTargetHeight != targetHeight)
 					log(1,


### PR DESCRIPTION
In case of small value of ratio, the TargetHeight may become zero and cause problem while instantiating BufferedImage.