### PR TITLE
Added Manifest attribute to enable usage inside Java 9 modules

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -71,7 +71,11 @@ limitations under the License.
 		<jar 
 			basedir="${dir.bin}" 
 			destfile="${dir.dist}/${name.file}-${version.major}.${version.minor}.jar" 
-			compress="no" />
+			compress="no">
+			<manifest>
+				<attribute name="Automatic-Module-Name" value="imgscalr.lib" />
+			</manifest>
+		</jar>
 	</target>
 
 	<target name="src">


### PR DESCRIPTION
With this attribute the project can be added with ease inside Gradle project that use Java 9 modules.